### PR TITLE
fix(config): correct max_strands default check from 128 to 64

### DIFF
--- a/tantra/core/npdna/config.py
+++ b/tantra/core/npdna/config.py
@@ -86,7 +86,7 @@ class NpDnaConfig:
         # Only set genome defaults if not explicitly configured
         if self.genome.latent_dim == 256:
             self.genome.latent_dim = min(512, self.hidden_size * 2)
-        if self.genome.max_strands == 128:
+        if self.genome.max_strands == 64:
             self.genome.max_strands = self.mesh.num_strands * self.num_layers
 
     @property

--- a/tantra/npdna/config.py
+++ b/tantra/npdna/config.py
@@ -86,7 +86,7 @@ class NpDnaConfig:
         # Only set genome defaults if not explicitly configured
         if self.genome.latent_dim == 256:
             self.genome.latent_dim = min(512, self.hidden_size * 2)
-        if self.genome.max_strands == 128:
+        if self.genome.max_strands == 64:
             self.genome.max_strands = self.mesh.num_strands * self.num_layers
 
     @property


### PR DESCRIPTION
## Bug Fix: config.py max_strands Default Check

**Source:** Code audit agent finding (🟡 config.py:89)

### Problem
`GenomeConfig` defines `max_strands: int = 64` as default, but `NpDnaConfig.__post_init__` checked for `== 128`. Since the default is `64`, this condition was **never True**, so the auto-sizing `self.genome.max_strands = self.mesh.num_strands * self.num_layers` never ran.

### Impact
All CONFIGS entries using the default `GenomeConfig()` (seed, nano, micro, small, medium) have `max_strands` stuck at `64` instead of being auto-sized to match their mesh configuration (e.g., `4×2=8` for seed config).

### Fix
Changed the comparison from `== 128` to `== 64` (matching `GenomeConfig`'s actual default).

### Files
- `tantra/core/npdna/config.py` (line 89)
- `tantra/npdna/config.py` (line 89, duplicate copy)