### PR TITLE
fix(safe-eval): add exponent validation wrapper for pow()

### DIFF
--- a/tantra/core/npdna/safe_eval.py
+++ b/tantra/core/npdna/safe_eval.py
@@ -32,13 +32,21 @@ _UNARY_OPS: dict[type[ast.unaryop], Callable[[Any], Any]] = {
     ast.USub: operator.neg,
 }
 
+
+def _safe_pow(a: Any, b: Any) -> Any:
+    """pow() wrapper that enforces the same exponent limit as the ** operator."""
+    if abs(b) > 12:
+        raise ValueError(f"Exponent too large: {b}")
+    return pow(a, b)
+
+
 _FUNCTIONS: dict[str, Callable[..., Any]] = {
     "abs": abs,
     "round": round,
     "min": min,
     "max": max,
     "sum": sum,
-    "pow": pow,
+    "pow": _safe_pow,
     "sqrt": math.sqrt,
     "sin": math.sin,
     "cos": math.cos,


### PR DESCRIPTION
## Bug Fix: safe_eval.py pow() Exponent Bypass

**Source:** Code audit agent finding

### Problem
The built-in `pow()` function was registered directly in `_FUNCTIONS` without exponent validation. While the `**` operator (ast.Pow) validates `abs(right) <= 12` in `_eval_node`, a simple function call like `pow(2, 100000)` would bypass this check entirely, creating a DoS/abort risk.

### Fix
Added `_safe_pow(a, b)` wrapper that enforces the same `abs(b) <= 12` threshold as the `**` operator. Replaced `pow` with `_safe_pow` in the allowed `_FUNCTIONS` dict.

### Files
- `tantra/core/npdna/safe_eval.py`