### PR TITLE
fix(plasticity): use OrderedDict for LRU eviction + single source of …

### DIFF
--- a/tantra/npdna/plasticity.py
+++ b/tantra/npdna/plasticity.py
@@ -10,6 +10,7 @@ Monitors training metrics and adapts the architecture:
 from __future__ import annotations
 
 import logging
+from collections import OrderedDict
 from dataclasses import dataclass, field
 
 import torch
@@ -68,7 +69,7 @@ class PlasticityEngine:
 
         self.events: list[PlasticityEvent] = []
         self.loss_history: list[float] = []
-        self._last_dead_reinit: set[tuple[int, int]] = set()
+        self._last_dead_reinit: OrderedDict[tuple[int, int], None] = OrderedDict()
         self._available_dead_strands: dict[int, list[int]] = {}
         self._checks_since_growth = grow_cooldown_checks
 
@@ -144,9 +145,13 @@ class PlasticityEngine:
     def _reuse_dead_for_overload(self, step: int, layer_i: int, mesh, overloaded: list[int], dead: list[int]) -> bool:
         """Reuse dead strands to handle overloaded capacity instead of growing new ones.
         
+        Uses ``self._available_dead_strands`` as the single source of truth
+        for available dead strands (the ``dead`` parameter is only used
+        as a fallback when the tracked list is unexpectedly empty).
+
         Returns True if dead strands were successfully reused.
         """
-        available = self._available_dead_strands.get(layer_i, [])
+        available = self._available_dead_strands.get(layer_i, []) or dead
         if not available:
             return False
         
@@ -167,7 +172,7 @@ class PlasticityEngine:
                     mesh.router.weight[dead_id].normal_(mean=0.0, std=nn_init_std)
                 
                 key = (layer_i, dead_id)
-                self._last_dead_reinit.discard(key)
+                self._last_dead_reinit.pop(key, None)
                 
                 msg = f"Layer {layer_i}: reused dead strand {dead_id} for overloaded capacity"
                 logger.info("Plasticity: %s", msg)
@@ -206,11 +211,11 @@ class PlasticityEngine:
                     nn_init_std = 1.0 / (max(1, mesh.router.weight.shape[1]) ** 0.5)
                     mesh.router.weight[s_id].normal_(mean=0.0, std=nn_init_std)
                 reinitialized.append(s_id)
-                self._last_dead_reinit.add(key)
+                self._last_dead_reinit[key] = None
         if len(self._last_dead_reinit) > 1000:
             to_remove = len(self._last_dead_reinit) - 1000
             for _ in range(to_remove):
-                self._last_dead_reinit.pop()
+                self._last_dead_reinit.popitem(last=False)
         return reinitialized
 
     def _check_vocab_pressure(self, step: int) -> list[PlasticityEvent]:


### PR DESCRIPTION
…truth for dead strands

Two bugs found by code audit:

1. set.pop() LRU eviction: _last_dead_reinit used set.pop() which removes an arbitrary element, not the oldest entry. Fix: replace set with OrderedDict with popitem(last=False) for true FIFO eviction.

2. Two sources of truth: _reuse_dead_for_overload received a 'dead' parameter but also read self._available_dead_strands independently. These could desync when dead strands are empty but stale data exists from a previous cycle. Fix: use self._available_dead_strands as single source of truth, falling back to the 'dead' parameter if empty.