### PR TITLE
fix(npdna): 7 bug patches — sentinel config, routing perf, JSON resilience, and more

### DIFF
--- a/tantra/core/npdna/checkpoint.py
+++ b/tantra/core/npdna/checkpoint.py
@@ -87,8 +87,9 @@ class CheckpointMixin:
 
         # Infer actual strand count from weights (beats stale metadata)
         inferred_strands = max(
-            (int(re.match(r"mesh_layers\.\d+\.strands\.(\d+)\.", k).group(1)) + 1
-             for k in state if re.match(r"mesh_layers\.\d+\.strands\.(\d+)\.", k)),
+            (int(m.group(1)) + 1
+             for k in state
+             if (m := re.match(r"mesh_layers\.\d+\.strands\.(\d+)\.", k))),
             default=meta.get("num_strands", 4),
         )
 

--- a/tantra/core/npdna/config.py
+++ b/tantra/core/npdna/config.py
@@ -14,9 +14,9 @@ from dataclasses import dataclass, field
 class GenomeConfig:
     """DNA weight generator configuration."""
 
-    latent_dim: int = 256
+    latent_dim: int | None = None  # None = auto-computed from hidden_size
     rank: int = 32
-    max_strands: int = 64
+    max_strands: int | None = None  # None = auto-computed from num_layers * mesh.num_strands
     encoder_hidden: int = 512
 
     @property
@@ -84,9 +84,9 @@ class NpDnaConfig:
         self.mesh.strand.state_size = self.state_size
         self.cortex.dim = self.hidden_size
         # Only set genome defaults if not explicitly configured
-        if self.genome.latent_dim == 256:
+        if self.genome.latent_dim is None:
             self.genome.latent_dim = min(512, self.hidden_size * 2)
-        if self.genome.max_strands == 64:
+        if self.genome.max_strands is None:
             self.genome.max_strands = self.mesh.num_strands * self.num_layers
 
     @property

--- a/tantra/core/npdna/cortex_autostore.py
+++ b/tantra/core/npdna/cortex_autostore.py
@@ -17,11 +17,15 @@ class CortexAutoStore:
     def _load(self):
         store_file = self.data_dir / "cortex_store.json"
         if store_file.exists():
-            self._store = json.loads(store_file.read_text())
+            try:
+                self._store = json.loads(store_file.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
+                logger.warning("CortexAutoStore: corrupt store file %s — starting fresh (%s)", store_file, exc)
+                self._store = {}
 
     def _save(self):
         store_file = self.data_dir / "cortex_store.json"
-        store_file.write_text(json.dumps(self._store, indent=2))
+        store_file.write_text(json.dumps(self._store, indent=2), encoding="utf-8")
 
     def auto_store(self, layer_name: str, representations: dict[str, Any], step: int):
         """Auto-store intermediate representations during training."""

--- a/tantra/core/npdna/generation.py
+++ b/tantra/core/npdna/generation.py
@@ -110,6 +110,7 @@ class GenerationMixin:
         context_window: int = 128,
         audio_inputs: Optional[Tensor] = None,
         image_inputs: Optional[Tensor] = None,
+        system: Optional[str] = None,
     ) -> str:
         return "".join(
             self.generate_stream(
@@ -124,6 +125,7 @@ class GenerationMixin:
                 context_window=context_window,
                 audio_inputs=audio_inputs,
                 image_inputs=image_inputs,
+                system=system,
             )
         )
 
@@ -140,8 +142,9 @@ class GenerationMixin:
         context_window: int = 128,
         audio_inputs: Optional[Tensor] = None,
         image_inputs: Optional[Tensor] = None,
+        system: Optional[str] = None,
     ) -> Generator[str, None, None]:
-        prompt = _build_chat_prompt(prompt)
+        prompt = _build_chat_prompt(prompt, system=system)
         prompt_ids = self.encode(prompt, allow_growth=False)
         self.last_prompt_len = len(prompt_ids)
         ids = list(prompt_ids) or [self.tokenizer.token_to_id.get("<bos>", 2)]
@@ -241,7 +244,7 @@ class GenerationMixin:
 
         telemetry = []
         for t, tok_id in enumerate(self.last_generated_ids):
-            tok_raw = self.tokenizer.id_to_token[tok_id] if tok_id < len(self.tokenizer.id_to_token) else f"<unk_{tok_id}>"
+            tok_raw = self.tokenizer.id_to_token[tok_id] if tok_id < self.tokenizer.size else f"<unk_{tok_id}>"
 
             layers_info = []
             for mesh in self.model.mesh_layers:

--- a/tantra/core/npdna/mesh.py
+++ b/tantra/core/npdna/mesh.py
@@ -85,33 +85,37 @@ class NeuralMesh(nn.Module):
         # Compute outputs from selected Strands
         output = torch.zeros_like(x)
 
-        for k_idx in range(K):
-            strand_indices = top_indices[:, :, k_idx]  # (B, T)
-            w = top_weights[:, :, k_idx].unsqueeze(-1)  # (B, T, 1)
+        # Gather all (batch, time, k_idx) triples and group by strand
+        # This replaces the O(K×N) nested loop with O(num_active_strands × avg_tokens_per_strand)
+        flat_indices = top_indices.reshape(B * T * K)  # (B*T*K,)
+        flat_weights = top_weights.reshape(B * T * K, 1)  # (B*T*K, 1)
+        flat_x = x.unsqueeze(2).expand(-1, -1, K, -1).reshape(B * T * K, -1)  # (B*T*K, H)
 
-            for s_id in range(N):
-                mask = strand_indices == s_id  # (B, T)
-                if not mask.any():
-                    continue
+        # Find unique strand indices and their inverse mapping
+        unique_strands, inverse = torch.unique(flat_indices, return_inverse=True)
+        unique_strands = unique_strands.tolist()  # move to host for iteration
 
-                # Gather tokens that route to this Strand
-                # Use a batched approach: find all (batch, time) positions
-                batch_idx, time_idx = torch.where(mask)
-                if len(batch_idx) == 0:
-                    continue
+        for s_id in unique_strands:
+            mask = inverse == int(s_id)  # use the pre-computed inverse
+            mask_flat = mask
+            if not mask_flat.any():
+                continue
 
-                # Extract relevant tokens
-                strand_input = x[batch_idx, time_idx].unsqueeze(1)  # (M, 1, H)
+            strand_tokens = flat_x[mask_flat].unsqueeze(1)  # (M, 1, H)
+            strand_weights = flat_weights[mask_flat]  # (M, 1)
 
-                # Process through Strand
-                strand_output = self.strands[s_id](strand_input).squeeze(1)  # (M, H)
+            # Process through Strand
+            strand_output = self.strands[s_id](strand_tokens).squeeze(1)  # (M, H)
 
-                # Weight and accumulate
-                token_weights = w[batch_idx, time_idx]  # (M, 1)
-                output[batch_idx, time_idx] += strand_output * token_weights
+            # Scatter back
+            flat_indices_masked = torch.where(mask_flat)[0]
+            batch_idx = flat_indices_masked // (T * K)
+            remainder = flat_indices_masked % (T * K)
+            time_idx = remainder // K
+            output[batch_idx, time_idx] += strand_output * strand_weights
 
-                # Track usage
-                self._usage_counts[s_id] += len(batch_idx)
+            # Track usage
+            self._usage_counts[s_id] += mask_flat.sum().item()
 
         # Load-balancing loss: encourage even distribution across Strands
         # Based on Switch Transformer's balance loss

--- a/tantra/core/npdna/plasticity.py
+++ b/tantra/core/npdna/plasticity.py
@@ -74,11 +74,11 @@ class PlasticityEngine:
         self._checks_since_growth = grow_cooldown_checks
 
     def record_loss(self, loss: float) -> None:
-        """Record a training loss value. Raises TypeError if loss is not numeric."""
+        """Record a training loss value. Rejects non-numeric and bool values."""
+        if isinstance(loss, bool):
+            raise TypeError(f"loss must be numeric, got bool")
         if not isinstance(loss, (int, float)):
             raise TypeError(f"loss must be numeric, got {type(loss).__name__}")
-        if isinstance(loss, bool):
-            raise TypeError("loss must be numeric, got bool")
         self.loss_history.append(loss)
 
     def check(self, step: int) -> list[PlasticityEvent]:

--- a/tantra/npdna/checkpoint.py
+++ b/tantra/npdna/checkpoint.py
@@ -87,8 +87,9 @@ class CheckpointMixin:
 
         # Infer actual strand count from weights (beats stale metadata)
         inferred_strands = max(
-            (int(re.match(r"mesh_layers\.\d+\.strands\.(\d+)\.", k).group(1)) + 1
-             for k in state if re.match(r"mesh_layers\.\d+\.strands\.(\d+)\.", k)),
+            (int(m.group(1)) + 1
+             for k in state
+             if (m := re.match(r"mesh_layers\.\d+\.strands\.(\d+)\.", k))),
             default=meta.get("num_strands", 4),
         )
 

--- a/tantra/npdna/config.py
+++ b/tantra/npdna/config.py
@@ -14,9 +14,9 @@ from dataclasses import dataclass, field
 class GenomeConfig:
     """DNA weight generator configuration."""
 
-    latent_dim: int = 256
+    latent_dim: int | None = None  # None = auto-computed from hidden_size
     rank: int = 32
-    max_strands: int = 64
+    max_strands: int | None = None  # None = auto-computed from num_layers * mesh.num_strands
     encoder_hidden: int = 512
 
     @property
@@ -84,9 +84,9 @@ class NpDnaConfig:
         self.mesh.strand.state_size = self.state_size
         self.cortex.dim = self.hidden_size
         # Only set genome defaults if not explicitly configured
-        if self.genome.latent_dim == 256:
+        if self.genome.latent_dim is None:
             self.genome.latent_dim = min(512, self.hidden_size * 2)
-        if self.genome.max_strands == 64:
+        if self.genome.max_strands is None:
             self.genome.max_strands = self.mesh.num_strands * self.num_layers
 
     @property

--- a/tantra/npdna/cortex_autostore.py
+++ b/tantra/npdna/cortex_autostore.py
@@ -27,7 +27,11 @@ class CortexAutoStore:
     def _load(self):
         store_file = self.data_dir / "cortex_store.json"
         if store_file.exists():
-            self._store = json.loads(store_file.read_text())
+            try:
+                self._store = json.loads(store_file.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
+                logger.warning("CortexAutoStore: corrupt store file %s — starting fresh (%s)", store_file, exc)
+                self._store = {}
 
     def _save(self):
         store_file = self.data_dir / "cortex_store.json"

--- a/tantra/npdna/generation.py
+++ b/tantra/npdna/generation.py
@@ -237,7 +237,7 @@ class GenerationMixin:
 
         telemetry = []
         for t, tok_id in enumerate(self.last_generated_ids):
-            tok_raw = self.tokenizer.id_to_token[tok_id] if tok_id < len(self.tokenizer.id_to_token) else f"<unk_{tok_id}>"
+            tok_raw = self.tokenizer.id_to_token[tok_id] if tok_id < self.tokenizer.size else f"<unk_{tok_id}>"
 
             layers_info = []
             for mesh in self.model.mesh_layers:

--- a/tantra/npdna/mesh.py
+++ b/tantra/npdna/mesh.py
@@ -85,33 +85,37 @@ class NeuralMesh(nn.Module):
         # Compute outputs from selected Strands
         output = torch.zeros_like(x)
 
-        for k_idx in range(K):
-            strand_indices = top_indices[:, :, k_idx]  # (B, T)
-            w = top_weights[:, :, k_idx].unsqueeze(-1)  # (B, T, 1)
+        # Gather all (batch, time, k_idx) triples and group by strand
+        # This replaces the O(K×N) nested loop with O(num_active_strands × avg_tokens_per_strand)
+        flat_indices = top_indices.reshape(B * T * K)  # (B*T*K,)
+        flat_weights = top_weights.reshape(B * T * K, 1)  # (B*T*K, 1)
+        flat_x = x.unsqueeze(2).expand(-1, -1, K, -1).reshape(B * T * K, -1)  # (B*T*K, H)
 
-            for s_id in range(N):
-                mask = strand_indices == s_id  # (B, T)
-                if not mask.any():
-                    continue
+        # Find unique strand indices and their inverse mapping
+        unique_strands, inverse = torch.unique(flat_indices, return_inverse=True)
+        unique_strands = unique_strands.tolist()  # move to host for iteration
 
-                # Gather tokens that route to this Strand
-                # Use a batched approach: find all (batch, time) positions
-                batch_idx, time_idx = torch.where(mask)
-                if len(batch_idx) == 0:
-                    continue
+        for s_id in unique_strands:
+            mask = inverse == int(s_id)  # use the pre-computed inverse
+            mask_flat = mask
+            if not mask_flat.any():
+                continue
 
-                # Extract relevant tokens
-                strand_input = x[batch_idx, time_idx].unsqueeze(1)  # (M, 1, H)
+            strand_tokens = flat_x[mask_flat].unsqueeze(1)  # (M, 1, H)
+            strand_weights = flat_weights[mask_flat]  # (M, 1)
 
-                # Process through Strand
-                strand_output = self.strands[s_id](strand_input).squeeze(1)  # (M, H)
+            # Process through Strand
+            strand_output = self.strands[s_id](strand_tokens).squeeze(1)  # (M, H)
 
-                # Weight and accumulate
-                token_weights = w[batch_idx, time_idx]  # (M, 1)
-                output[batch_idx, time_idx] += strand_output * token_weights
+            # Scatter back
+            flat_indices_masked = torch.where(mask_flat)[0]
+            batch_idx = flat_indices_masked // (T * K)
+            remainder = flat_indices_masked % (T * K)
+            time_idx = remainder // K
+            output[batch_idx, time_idx] += strand_output * strand_weights
 
-                # Track usage
-                self._usage_counts[s_id] += len(batch_idx)
+            # Track usage
+            self._usage_counts[s_id] += mask_flat.sum().item()
 
         # Load-balancing loss: encourage even distribution across Strands
         # Based on Switch Transformer's balance loss


### PR DESCRIPTION
## Summary

7 bug fixes across NP-DNA core modules:

1. **config.py** — Sentinel value masking:  and  were used as defaults but also as sentinels for auto-compute. Changed to -based sentinel pattern so explicit user values are never overwritten. 🔴

2. **mesh.py** — Performance: the top-k routing forward pass iterated over **all** N strands (O(K×N) per token), creating PyTorch ops for strands with zero routed tokens. Switched to a flat gather + /inverse-mask approach — only active strands are touched. 🔴

3. **plasticity.py** — Logic:  checked  before . In Python,  is a subclass of , so / would pass the first guard and only fail on the second — confusing. Reversed order. 🟡

4. **generation.py** — Missing feature:  parameter was defined in  but never forwarded from  or . Added passthrough. 🟡

5. **generation.py** — Bounds:  used  instead of . The list may not equal the vocab size. 🟡

6. **checkpoint.py** — Cleanup:  called twice per key in  comprehension. Used walrus operator () to compute once. 🟢

7. **cortex_autostore.py** — Resilience:  crashes on corrupted JSON. Wrapped in try/except with graceful reset + warning log. 🟡

Closes # (auto-linked via branch name)