### PR TITLE
fix(cortex): restore training mode after sleep_cycle & clear stale indices on empty

### DIFF
--- a/tantra/core/compare_checkpoints.py
+++ b/tantra/core/compare_checkpoints.py
@@ -139,7 +139,6 @@ def benchmark_core(core: NpDnaCore, test_texts: list[str], label: str) -> dict:
     result = core.generate("Hello world", max_tokens=GENERATE_TOKENS)
     elapsed = time.perf_counter() - start
     tokens_generated = len(core.encode(result, allow_growth=False))
-    tokens_generated / max(0.001, elapsed)
 
     # ── 5. Memory ───────────────────────────────────────────────────────────
     print(f"  [{label}] Measuring memory...", flush=True)

--- a/tantra/npdna/cortex.py
+++ b/tantra/npdna/cortex.py
@@ -114,9 +114,8 @@ class MemoryCortex(torch.nn.Module):
             (values, scores) â€” retrieved value vectors and similarity scores.
         """
         if self.size == 0:
-            if not self.training:
-                self._last_top_indices = None
-                self._last_top_scores = None
+            self._last_top_indices = None
+            self._last_top_scores = None
             dim = self.config.dim
             k = top_k or self.config.top_k
             if query.dim() == 1:
@@ -355,6 +354,7 @@ class MemoryCortex(torch.nn.Module):
                 loss_fn = torch.nn.CrossEntropyLoss()
                 
                 self._is_sleeping = True
+                was_training = model.training
                 try:
                     model.train()
                     for entry in high_freq_entries:
@@ -380,6 +380,8 @@ class MemoryCortex(torch.nn.Module):
                             logger.warning("Failed to consolidate fact '%s' to weights: %s", entry.source[:30], ex)
                 finally:
                     self._is_sleeping = False
+                    if not was_training:
+                        model.eval()
 
         self.entries = consolidated_entries
         self._invalidate_cache()


### PR DESCRIPTION
## Changes

### 1. Fix model training mode in `sleep_cycle()` 🟡
- `model.train()` was called but if the model was in `eval()` mode before sleep, it stayed in `train()` mode afterward.
- Now saves `model.training` state and restores it in the `finally` block.

### 2. Fix stale `_last_top_indices` on empty cortex 🟡
- When `size==0` and `self.training` was `True`, `_last_top_indices` was left unchanged (stale from last retrieval).
- Now always cleared to `None` on empty retrieve, regardless of training mode.

### 3. Remove dead expression in `compare_checkpoints.py` 🟢
- `tokens_generated / max(0.001, elapsed)` computed a value that was discarded.