### PR TITLE
fix(compare_checkpoints): remove dead expression / unused computed value

### DIFF
--- a/tantra/core/compare_checkpoints.py
+++ b/tantra/core/compare_checkpoints.py
@@ -139,7 +139,6 @@ def benchmark_core(core: NpDnaCore, test_texts: list[str], label: str) -> dict:
     result = core.generate("Hello world", max_tokens=GENERATE_TOKENS)
     elapsed = time.perf_counter() - start
     tokens_generated = len(core.encode(result, allow_growth=False))
-    tokens_generated / max(0.001, elapsed)
 
     # ── 5. Memory ───────────────────────────────────────────────────────────
     print(f"  [{label}] Measuring memory...", flush=True)


### PR DESCRIPTION
**Bug:** Line 142 contained `tokens_generated / max(0.001, elapsed)` — a value computed but never assigned or used. This is a dead code path that adds confusion and does nothing at runtime.

**Fix:** Removed the no-op expression entirely.
