### PR TITLE
fix(cortex): always clear _last_top_indices/_last_top_scores when cortex is empty

### DIFF
--- a/tantra/npdna/cortex.py
+++ b/tantra/npdna/cortex.py
@@ -114,9 +114,8 @@ class MemoryCortex(torch.nn.Module):
             (values, scores) â€” retrieved value vectors and similarity scores.
         """
         if self.size == 0:
-            if not self.training:
-                self._last_top_indices = None
-                self._last_top_scores = None
+            self._last_top_indices = None
+            self._last_top_scores = None
             dim = self.config.dim
             k = top_k or self.config.top_k
             if query.dim() == 1:


### PR DESCRIPTION
**Bug:** The `retrieve()` method's early return for empty cortex (`self.size == 0`) only cleared `_last_top_indices` and `_last_top_scores` when `not self.training`. In training mode, stale indices from a prior non-empty retrieve could persist, causing downstream consumers to read outdated state.

**Fix:** Always set `_last_top_indices = None` and `_last_top_scores = None` on the empty-cortex path, regardless of training mode.
