### PR TITLE
fix(plasticity): partition dead strands to avoid double reinit; grow_for_overload respects layer_specs

### DIFF
--- a/tantra/npdna/plasticity.py
+++ b/tantra/npdna/plasticity.py
@@ -163,12 +163,6 @@ class PlasticityEngine:
                 events.append(PlasticityEvent(step, "dead_strands", msg))
                 dead_strands_by_layer[layer_i] = dead
                 self._available_dead_strands[layer_i] = dead
-                if self.reinit_dead_strands:
-                    reinitialized = self._reinit_dead_strands(layer_i, mesh, dead)
-                    if reinitialized:
-                        reset_msg = f"Layer {layer_i}: reinitialized dead strands {reinitialized}"
-                        logger.info("Plasticity: %s", reset_msg)
-                        events.append(PlasticityEvent(step, "reinit_strands", reset_msg))
 
             if overloaded:
                 msg = f"Layer {layer_i}: {len(overloaded)} overloaded strands {overloaded}"
@@ -184,6 +178,17 @@ class PlasticityEngine:
                             events.append(growth)
                             self._checks_since_growth = 0
                             grew_this_check = True
+
+            # Only reinit dead strands that were NOT consumed by reuse above.
+            if dead and self.reinit_dead_strands:
+                # After _reuse_dead_for_overload, strands still in
+                # _available_dead_strands are the ones NOT consumed.
+                reinit_targets = self._available_dead_strands.get(layer_i, [])
+                reinitialized = self._reinit_dead_strands(layer_i, mesh, reinit_targets)
+                if reinitialized:
+                    reset_msg = f"Layer {layer_i}: reinitialized dead strands {reinitialized}"
+                    logger.info("Plasticity: %s", reset_msg)
+                    events.append(PlasticityEvent(step, "reinit_strands", reset_msg))
 
             mesh.reset_usage()
 
@@ -226,7 +231,11 @@ class PlasticityEngine:
 
     def _grow_for_overload(self, step: int, reason: str) -> PlasticityEvent | None:
         model = self.core.model
-        current = model.config.mesh.num_strands
+        # Use per-layer specs if available, else fall back to config default
+        if model.layer_specs:
+            current = max(spec.num_strands for spec in model.layer_specs)
+        else:
+            current = model.config.mesh.num_strands
         max_per_layer = 64
         if current >= max_per_layer:
             return None
@@ -234,7 +243,9 @@ class PlasticityEngine:
             return None
 
         model.grow_strands(1)
-        msg = f"grew strands per layer {current} -> {model.config.mesh.num_strands}; reason: {reason}"
+        # Read updated value after growth
+        new_count = max(spec.num_strands for spec in model.layer_specs) if model.layer_specs else model.config.mesh.num_strands
+        msg = f"grew strands per layer {current} -> {new_count}; reason: {reason}"
         logger.info("Plasticity: %s", msg)
         return PlasticityEvent(step, "grow_strands", msg)
 


### PR DESCRIPTION
**Bugs fixed:**

**1. Double reinitialization of dead strands.**  
`_check_strand_usage` first called `_reinit_dead_strands` on ALL dead strands (reinitializing their genome seeds and router weights), then `_reuse_dead_for_overload` called the same reinitialization on the same dead strands. The fix partitions dead strands: those consumed by `_reuse_dead_for_overload` are removed from `_available_dead_strands`, and only the unconsumed remainder reach `_reinit_dead_strands`.

**2. `_grow_for_overload` ignored per-layer `num_strands`.**  
It read `model.config.mesh.num_strands` which may not reflect actual per-layer strand counts in `layer_specs`. Now it reads from `layer_specs` when available, falling back to the config default.
