### PR TITLE
refactor(context): replace confusing 'not seen.add(l)' anti-pattern in deduplicate_lines

### DIFF
--- a/tantra/core/context.py
+++ b/tantra/core/context.py
@@ -128,9 +128,15 @@ class ContextCompressor:
         return re.sub(r'\n{3,}', '\n\n', text)
 
     def deduplicate_lines(self, text: str) -> str:
+        """Deduplicate lines while preserving order."""
         lines = text.split("\n")
-        seen = set()
-        return "\n".join(l for l in lines if l not in seen and not seen.add(l))
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for line in lines:
+            if line not in seen:
+                seen.add(line)
+                deduped.append(line)
+        return "\n".join(deduped)
 
 
 class PromptCache:


### PR DESCRIPTION
**Anti-pattern:** `deduplicate_lines` used a one-liner `return "\n".join(l for l in lines if l not in seen and not seen.add(l))` which relies on `set.add()` returning `None` (falsy). This is hard to read and depends on a CPython implementation detail.

**Fix:** Replaced with an explicit `for` loop that checks `if line not in seen`, appends to a result list, and adds to the set — standard, readable, and equivalent.
