### PR TITLE
fix: prevent device mismatch in empty cortex retrieve()

### DIFF
--- a/tantra/npdna/cortex.py
+++ b/tantra/npdna/cortex.py
@@ -119,8 +119,8 @@ class MemoryCortex(torch.nn.Module):
             dim = self.config.dim
             k = top_k or self.config.top_k
             if query.dim() == 1:
-                return torch.zeros(k, dim), torch.zeros(k)
-            return torch.zeros(query.size(0), k, dim), torch.zeros(query.size(0), k)
+                return torch.zeros(k, dim, device=query.device, dtype=query.dtype), torch.zeros(k, device=query.device, dtype=query.dtype)
+            return torch.zeros(query.size(0), k, dim, device=query.device, dtype=query.dtype), torch.zeros(query.size(0), k, device=query.device, dtype=query.dtype)
 
         top_k = min(top_k or self.config.top_k, self.size)
 


### PR DESCRIPTION
## Description

When MemoryCortex is empty, `retrieve()` returned CPU zero tensors regardless of the query tensor's device. This causes a runtime crash during GPU inference because downstream operations expect tensors on the same device as the query.

## Fix

Added `device=query.device, dtype=query.dtype` to all zero-tensor creation in the empty-cortex path.

## Testing

- [x] Verified shape correctness for both 1D and batched queries
- [x] Device now matches query device automatically