### PR TITLE
fix: prevent in-place tensor mutation in sampling helpers

### DIFF
--- a/tantra/npdna/generation.py
+++ b/tantra/npdna/generation.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 def _apply_repetition_penalty(logits: Tensor, seen_ids: list[int], penalty: float) -> Tensor:
     if penalty <= 1.0:
         return logits
+    logits = logits.clone()
     for tok_id in set(seen_ids[-128:]):
         if 0 <= tok_id < logits.numel():
             logits[tok_id] /= penalty
@@ -48,6 +49,7 @@ def _apply_top_k(logits: Tensor, k: int) -> Tensor:
 def _apply_top_p(logits: Tensor, p: float) -> Tensor:
     if p >= 1.0:
         return logits
+    logits = logits.clone()
     sorted_logits, sorted_indices = torch.sort(logits, descending=True)
     cum_probs = torch.cumsum(torch.softmax(sorted_logits, dim=-1), dim=-1)
     remove = cum_probs > p


### PR DESCRIPTION
## Description

`_apply_repetition_penalty` and `_apply_top_p` mutated the input `logits` tensor in-place (`logits[tok_id] /= penalty`, `logits[sorted_indices[remove]] = float("-inf")`). While the caller currently clones, this is a fragile API pattern — future callers may not.

## Fix

Added `logits = logits.clone()` at the start of both functions, ensuring the input tensor is never modified. This makes the functions pure (no side effects) and safe to call with any tensor.

## Safety

All existing callers already pass `.clone()` tensors, so this change is purely an API hardening — no behavioral change.