### PR TITLE
fix: enable sharded checkpoint format loading

### DIFF
--- a/tantra/npdna/checkpoint.py
+++ b/tantra/npdna/checkpoint.py
@@ -94,8 +94,12 @@ class CheckpointMixin:
             state = torch.load(path / "model.pt", map_location="cpu", weights_only=True)
         elif cls._is_component_format(path):
             state = cls._load_components(path)
+        elif cls._is_sharded_format(path):
+            state = cls._load_sharded(path, cls._read_shard_index(path))
         else:
-            raise FileNotFoundError(f"Checkpoint at {path} has neither model.pt nor component model_index.json")
+            raise FileNotFoundError(
+                f"Checkpoint at {path} has neither model.pt nor component nor shard files"
+            )
 
         # Infer actual strand count from weights (beats stale metadata)
         inferred_strands = max(
@@ -198,6 +202,20 @@ class CheckpointMixin:
             return "component_files" in idx
         except Exception:
             return False
+
+    @staticmethod
+    def _is_sharded_format(path: Path) -> bool:
+        """Check if model_index.json points to shard files (v2)."""
+        try:
+            idx = json.loads((path / "model_index.json").read_text(encoding="utf-8"))
+            return "weight_files" in idx
+        except Exception:
+            return False
+
+    @staticmethod
+    def _read_shard_index(path: Path) -> dict:
+        """Read and return the model_index.json content for sharded format."""
+        return json.loads((path / "model_index.json").read_text(encoding="utf-8"))
 
     @staticmethod
     def _load_components(path: Path) -> dict[str, torch.Tensor]:


### PR DESCRIPTION
## Description

The `_load_sharded` method existed but was unreachable — the `load()` method only checked for `model.pt` and component format. Sharded checkpoints (v2 format with `weight_files` in `model_index.json`) would always hit `FileNotFoundError`.

## Changes

1. Added `_is_sharded_format()` — detects sharded format by checking for `weight_files` key
2. Added `_read_shard_index()` — helper to read the index file
3. Updated `load()` to check sharded format as the third fallback before raising

Now all three checkpoint formats are loadable:
- Single `model.pt` file
- Component files (v3, `component_files`)
- Shard files (v2, `weight_files`)