### PR TITLE
chore: remove redundant max_strands assignment in checkpoint load

### DIFF
--- a/tantra/npdna/checkpoint.py
+++ b/tantra/npdna/checkpoint.py
@@ -144,9 +144,8 @@ class CheckpointMixin:
             genome=genome_cfg,
             cortex=cortex_cfg,
         )
-        config.genome.max_strands = meta.get("genome_max_strands", inferred_strands * meta["num_layers"])
 
-        # Avoid circular import â€” import NpDnaModel here
+        # Avoid circular import — import NpDnaModel here
         from .model import NpDnaModel
         model = NpDnaModel(config)
 


### PR DESCRIPTION
## Description

 was already set correctly on line ~130 inside the  constructor (using ). The duplicate assignment on line 147 (after  construction) had no effect since the value was identical. Removed the dead code.