### PR TITLE
fix: use lazy %-formatting in missed logger call

### DIFF
--- a/tantra/core/model_failover.py
+++ b/tantra/core/model_failover.py
@@ -528,7 +528,7 @@ class ModelFailover:
         if name not in self._providers:
             raise ValueError(f"Unknown provider: {name}")
         self._current_provider = name
-        logger.info(f"Manual provider switch: {name}")
+        logger.info("Manual provider switch: %s", name)
 
 
 def create_failover_from_config(config: dict[str, Any]) -> ModelFailover:


### PR DESCRIPTION
Fixes one more logger f-string on line 531 that was missed in PR #24.